### PR TITLE
🩹 Fix connection refresh and modal state issues

### DIFF
--- a/src/components/connection-modal/connection-modal.actions.ts
+++ b/src/components/connection-modal/connection-modal.actions.ts
@@ -22,19 +22,21 @@ export async function loadConnection(connectionId: string) {
 export async function saveConnection(
   connectionId: string | undefined,
   connection: StateDatabase["connections"]
-) {
+): Promise<string> {
   const stateDb = await getStateDb();
 
   if (!connectionId) {
+    const newId = randomUUID();
     await stateDb
       .insertInto('connections')
       .values({
-        id: randomUUID(),
+        id: newId,
         name: connection.name,
         type: connection.type,
         details: JSON.stringify(connection.details) as any,
       })
       .execute();
+    return newId;
   } else {
     await stateDb
       .updateTable('connections')
@@ -45,5 +47,6 @@ export async function saveConnection(
       })
       .where('id', '=', connectionId)
       .execute();
+    return connectionId;
   }
 }

--- a/src/components/connection-modal/connection-modal.tsx
+++ b/src/components/connection-modal/connection-modal.tsx
@@ -3,7 +3,7 @@ import { cn } from '@/lib/utils';
 import { DialogTitle } from '@radix-ui/react-dialog';
 import { useQuery } from '@tanstack/react-query';
 import { PlugIcon, SettingsIcon, X } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { ItemInlineView } from '../explorer/item-views/item-inline-view';
 import { Button } from '../ui/button';
 import {
@@ -20,7 +20,7 @@ import { TableTab } from './tab.table';
 export function ConnectionModal({
   isOpen,
   onOpenChange,
-  connectionId,
+  connectionId: initialConnectionId,
   initialTableName,
   initialTablePage,
 }: {
@@ -30,6 +30,13 @@ export function ConnectionModal({
   initialTableName?: string;
   initialTablePage?: 'general' | 'inline-view' | 'card-view' | 'list-view';
 }) {
+  const [connectionId, setConnectionId] = useState(initialConnectionId);
+  
+  // Update connectionId when the prop changes
+  useEffect(() => {
+    setConnectionId(initialConnectionId);
+  }, [initialConnectionId]);
+
   const tablesQuery = useQuery({
     queryKey: ['tables', connectionId],
     queryFn: () => getTables(connectionId ?? ''),
@@ -168,6 +175,7 @@ export function ConnectionModal({
               <ConnectionTab
                 connectionId={connectionId}
                 onDelete={() => onOpenChange(false)}
+                onConnectionIdChange={setConnectionId}
               />
             </TabsContent>
 

--- a/src/components/connection-modal/connection-modal.tsx
+++ b/src/components/connection-modal/connection-modal.tsx
@@ -3,7 +3,7 @@ import { cn } from '@/lib/utils';
 import { DialogTitle } from '@radix-ui/react-dialog';
 import { useQuery } from '@tanstack/react-query';
 import { PlugIcon, SettingsIcon, X } from 'lucide-react';
-import { useMemo, useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { ItemInlineView } from '../explorer/item-views/item-inline-view';
 import { Button } from '../ui/button';
 import {

--- a/src/components/connection-modal/tab.connection.tsx
+++ b/src/components/connection-modal/tab.connection.tsx
@@ -66,6 +66,8 @@ export const ConnectionTab = forwardRef<
         title: 'Success',
         description: 'Connection settings saved successfully',
       });
+      // Invalidate connections query to refresh the list
+      queryClient.invalidateQueries({ queryKey: ['connections'] });
     },
   });
 

--- a/src/components/connection-modal/tab.connection.tsx
+++ b/src/components/connection-modal/tab.connection.tsx
@@ -34,8 +34,12 @@ type FormValues = {
 
 export const ConnectionTab = forwardRef<
   HTMLFormElement,
-  { connectionId?: string; onDelete?: () => void }
->(({ connectionId, onDelete }, ref) => {
+  { 
+    connectionId?: string; 
+    onDelete?: () => void;
+    onConnectionIdChange?: (connectionId: string) => void;
+  }
+>(({ connectionId, onDelete, onConnectionIdChange }, ref) => {
   const queryClient = useQueryClient();
   const connectionQuery = useQuery({
     queryKey: ['connection', connectionId],
@@ -61,13 +65,17 @@ export const ConnectionTab = forwardRef<
       // You could also trigger the global error handler manually if needed:
       browserLogger.error('Connection save failed:', {error});
     },
-    onSuccess: () => {
+    onSuccess: (savedConnectionId) => {
       toast({
         title: 'Success',
         description: 'Connection settings saved successfully',
       });
       // Invalidate connections query to refresh the list
       queryClient.invalidateQueries({ queryKey: ['connections'] });
+      // Update the connection ID if this was a new connection
+      if (!connectionId && savedConnectionId && onConnectionIdChange) {
+        onConnectionIdChange(savedConnectionId);
+      }
     },
   });
 


### PR DESCRIPTION
## Summary
Fixes issues where creating new connections didn't refresh the application data and the edit modal didn't show proper UI elements after saving new connections.

## Changes Made

### 🩹 Connection List Refresh Fix
- Added `queryClient.invalidateQueries({ queryKey: ['connections'] })` to `saveConnectionMutation.onSuccess`
- Ensures new connections appear immediately in the connections list without page refresh
- Matches existing behavior in `deleteConnectionMutation`

### ✨ Modal State Management Enhancement  
- Modified `saveConnection` action to return the connection ID (new or existing)
- Added state management in `ConnectionModal` to track `connectionId` changes internally
- Enhanced `ConnectionTab` to accept `onConnectionIdChange` callback
- Delete button, Connect button, and Tables section now appear immediately after saving new connection

## Testing
- ✅ Reproduced original issue using Playwright
- ✅ Verified fix works: new connections appear immediately in list
- ✅ Verified modal updates: delete button appears after creating new connection
- ✅ Verified tables section becomes available after save
- ✅ Cleaned up test connections to maintain clean state

## Before/After Behavior

**Before:**
1. Create new connection → Save → List doesn't refresh, delete button missing
2. User must manually reload page to see new connection
3. Modal remains in "new connection" state even after save

**After:**
1. Create new connection → Save → List refreshes automatically, delete button appears
2. Full modal functionality available immediately
3. Seamless user experience with proper state management

Fixes the connection refresh issue and improves overall UX for connection management.